### PR TITLE
Allow letters in rule+article numbering

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -48,7 +48,7 @@ function titleForSection(section) {
 var currentAnchorType
 function headerForSection(section) {
 	var result
-	var id = parseInt(section.index)
+	var id = section.index
 	if (section.type === 'part') {
 		result = "<h1>"
 		if (id) result += "PART " + romanize(id) + "<br>"


### PR DESCRIPTION
@nickjs Not sure a parseInt is required here. It also cuts off the letter in things like "Article 120a".